### PR TITLE
Add private-eye

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,4 +26,7 @@ defaults:
     values:
       layout: page
 
-# This should be merged
+scripts:
+  - /assets/uswds/js/uswds.min.js
+  - /assets/js/private-eye.js
+  - /assets/js/application.js

--- a/_pages/index.md
+++ b/_pages/index.md
@@ -14,7 +14,7 @@ subnav:
 ---
 ## Section One
 
-Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Eu facilisis sed odio morbi quis commodo odio aenean sed. Ultrices gravida dictum fusce ut placerat orci nulla pellentesque. Lectus urna duis convallis convallis tellus id interdum. Neque vitae tempus quam pellentesque nec. Sit amet tellus cras adipiscing enim eu. Nisl nisi scelerisque eu ultrices vitae. Ac felis donec et odio pellentesque. Suscipit tellus mauris a diam maecenas. Diam quam nulla porttitor massa id neque. Eget nulla facilisi etiam dignissim. Bibendum neque egestas congue quisque egestas.
+Lorem ipsum dolor sit amet. [This is a link to a private, internal site](https://eopf.opm.gov). Eu facilisis sed odio morbi quis commodo odio aenean sed. Ultrices gravida dictum fusce ut placerat orci nulla pellentesque. Lectus urna duis convallis convallis tellus id interdum. Neque vitae tempus quam pellentesque nec. Sit amet tellus cras adipiscing enim eu. Nisl nisi scelerisque eu ultrices vitae. Ac felis donec et odio pellentesque. Suscipit tellus mauris a diam maecenas. Diam quam nulla porttitor massa id neque. Eget nulla facilisi etiam dignissim. Bibendum neque egestas congue quisque egestas.
 
 ## Section Two
 

--- a/assets/js/application.js
+++ b/assets/js/application.js
@@ -1,0 +1,38 @@
+document.addEventListener('DOMContentLoaded', function() {
+  PrivateEye({
+    defaultMessage: "This link is private to GSA.",
+    ignoreUrls: [
+      '18f.slack.com',
+      'anywhere.gsa.gov',
+      'bookit.gsa.gov',
+      'calendar.gsa.gov',
+      'connect.gsa.gov',
+      'docs.google.com',
+      'drive.google.com',
+      'ea.gsa.gov',
+      'email.gsa.gov',
+      'eopf.opm.gov',
+      'gcims.gsa.gov',
+      'github.com/18F/Accessibility_Reviews',
+      'github.com/18F/blog-drafts',
+      'github.com/18F/codereviews',
+      'github.com/18F/DevOps',
+      'github.com/18F/Infrastructure',
+      'github.com/18F/security-incidents',
+      'github.com/18F/staffing',
+      'github.com/18F/team-api.18f.gov',
+      'github.com/18F/writing-lab',
+      'gkey.gsa.gov',
+      'gsa-tts.slack.com',
+      'gsa.my.salesforce.com',
+      'gsaolu.gsa.gov',
+      'hrlinks.gsa.gov',
+      'hrprod.hr.gsa.gov',
+      'insite.gsa.gov',
+      'mail.gsa.gov',
+      'meet.gsa.gov',
+      'sign.gsa.gov',
+      'tock.18f.gov'
+    ]
+  });
+}, false );

--- a/assets/js/private-eye.js
+++ b/assets/js/private-eye.js
@@ -1,0 +1,105 @@
+// https://github.com/18F/private-eye version 2.0.0
+(function() {
+  'use strict';
+
+  var STYLES = 'a.private-link::after { content: "\\1F512"; font-size: 0.75em; vertical-align: top; }';
+  var STYLES_ID = '_privateEye-styles';
+
+  var DEFAULT_OPTIONS = {
+    defaultMessage: 'This is a link to a private site, which may or may not be accessible to you.',
+    wrapper: ''
+  };
+
+  var isString = function(str) { return !!str && typeof str === 'string'; };
+  var isArray = function(arr) { return !!arr && arr.length; };
+
+  var optionValidators = {
+    defaultMessage: isString,
+    wrapper: isString,
+    ignoreUrls: isArray,
+  };
+
+  function setStyles() {
+    var styles = document.createElement('style');
+    styles.innerHTML = STYLES;
+    styles.id = STYLES_ID;
+    document.body.appendChild(styles);
+  }
+
+  function getOptions(opts) {
+    var newObj = {};
+
+    for (var prop in DEFAULT_OPTIONS) {
+      newObj[prop] = DEFAULT_OPTIONS[prop];
+    }
+
+    for (var prop in opts) {
+      var val = opts[prop];
+
+      if (optionValidators[prop](val)) {
+        newObj[prop] = val;
+      }
+    }
+
+    return newObj;
+  }
+
+  var PrivateEye = function(opts) {
+    // The old docs recommend calling this as a function. This is here to detect
+    // those cases and make sure backward compatibility stays intact now that the
+    // new syntax is preferred.
+    if (!(this instanceof PrivateEye)) {
+      return new PrivateEye(opts);
+    }
+
+    // Don't add the styles to the page more than once.
+    if (!document.getElementById(STYLES_ID)) {
+      setStyles();
+    }
+
+    this.opts = getOptions(opts);
+
+    this.checkLinks();
+  };
+
+  PrivateEye.prototype.checkLinks = function() {
+    var self = this;
+
+    this.opts.ignoreUrls.forEach(function(url) {
+      var hrefValue;
+      var titleValue;
+
+      // If the `url` is an Object, then parse the properties `message` & `url`
+      if (url === Object(url)) {
+        titleValue = url.message;
+        hrefValue = url.url;
+      } else {
+        hrefValue = url;
+        titleValue = self.opts.defaultMessage;
+      }
+
+      var wrapper = self.opts.wrapper.length ? self.opts.wrapper + ' ' : '';
+      var selector = wrapper + 'a';
+      var anchors = document.querySelectorAll(selector);
+
+      Array.prototype.forEach.call(anchors, function(anchor) {
+        var anchorHref = anchor.href.toLowerCase().trim();
+
+        if (anchorHref.indexOf(hrefValue.toLowerCase()) !== -1) {
+          anchor.className += ' private-link';
+
+          // Only replace the anchor's title if it is empty
+          if (!anchor.title) {
+            anchor.title = titleValue;
+          }
+        }
+      });
+    });
+  }
+
+  if (typeof module === 'object' && typeof module.exports === 'object') {
+    module.exports = PrivateEye;
+  } else {
+    window.PrivateEye = PrivateEye;
+  }
+})();


### PR DESCRIPTION
Provenance of changes:
- private domains/URLs from 18F/handbook (https://github.com/18F/handbook/blob/master/javascripts/application.js)
- defaultMessage from 18F/ux-guide (https://github.com/18F/ux-guide/pull/176)
- code from 18F/private-eye (https://github.com/18F/private-eye/releases/tag/v2.0.0)

The code almost never changes, so skip npm/package.json and just
duplicate as other handbooks have done.