### PR TITLE
Tweak the footer/anchor API

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -1,0 +1,2 @@
+# Explicitly disable footer; only using anchor
+type:

--- a/_data/override/anchor.yml
+++ b/_data/override/anchor.yml
@@ -1,2 +1,3 @@
-edit_page: true
+edit_page:
+  text: "Edit this page"
 last_updated: true

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,26 +1,39 @@
+{% assign footer = site.data.footer %}
+
+{% if footer.type == 'slim' %}
+  {% include components/footer--slim.html %}
+{% elsif footer.type == 'default' or footer.type == 'medium' %}
+  {% include components/footer--default.html %}
+{% elsif footer.type == 'big' %}
+  {% include components/footer--big.html %}
+{% endif %}
+
 {% assign anchor = site.data.anchor %}
+
 <section class="anchor" data-uswds="1.0">
 {% if anchor.edit_page or (anchor.last_updated and page.last_modified_at) %}
-<div class="component-anchor-meta">
-  <div class="grid-container grid-container-desktop">
-    <div class="grid-row tablet-lg:grid-gap-2">
-      <div class="grid-col-12">
-        <div class="page-meta">
-          <p>
-            {% if anchor.last_updated and page.last_modified_at %}
-            <span><small>Last updated: {{ page.last_modified_at | date: '%B %d, %Y' }}</small></span>
-            {% endif %}
-            {% if anchor.edit_page %}
-            <span>
-              {% include components/github-edit.html footer=footer path=page.path %}
-            </span>
-            {% endif %}
-          </p>
+  {% unless footer.type %}
+    <div class="component-anchor-meta">
+      <div class="grid-container grid-container-desktop">
+        <div class="grid-row tablet-lg:grid-gap-2">
+          <div class="grid-col-12">
+            <div class="page-meta">
+              <p>
+                {% if anchor.last_updated and page.last_modified_at %}
+                <span><small>Last updated: {{ page.last_modified_at | date: '%B %d, %Y' }}</small></span>
+                {% endif %}
+                {% if anchor.edit_page %}
+                <span>
+                  {% include components/github-edit.html footer=anchor path=page.path %}
+                </span>
+                {% endif %}
+              </p>
+            </div>
+          </div>
         </div>
       </div>
     </div>
-  </div>
-</div>
+  {% endunless %}
 {% endif %}
 <div class="component-anchor">
   <div class="usa-accordion">


### PR DESCRIPTION
- Restore the ability to display the standard uswds-jekyll footer
- Explicitly turn the standard footer off
- Structure the anchor.yml edit_page key like the footer.yml one
- Disable the anchor last_updated, edit_page if footer enabled