### PR TITLE
Fix action to pull from default branch

### DIFF
--- a/.github/actions/merge-template/action.yml
+++ b/.github/actions/merge-template/action.yml
@@ -5,15 +5,12 @@ runs:
   using: "composite"
   steps:
     - run: |
-        echo 'override.yml merge=ours' >> .gitattributes
         echo 'README.md merge=ours' >> .gitattributes
-        echo '_pages/* merge=ours' >> .gitattributes
-        echo '_data/override/* merge=ours' >> .gitattributes
+        echo '_guide/* merge=ours' >> .gitattributes
         git config --global merge.ours.driver true
         git config user.name github-actions
         git config user.email github-actions@github.com
         git remote add -f upstream "https://github.com/18F/isildurs-bane.git"
-        git checkout master
-        git merge upstream/master
+        git merge upstream/main
         git push
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,7 +9,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          ref: master
           fetch-depth: 0 
       - name: Merge Template
         uses: ./.github/actions/merge-template


### PR DESCRIPTION
Just use default branch, remove master references. Also fix references to renamed paths that represent guide-specific files.