### PR TITLE
Allow unrelated histories for GitHub template

### DIFF
--- a/.github/actions/merge-template/action.yml
+++ b/.github/actions/merge-template/action.yml
@@ -11,6 +11,6 @@ runs:
         git config user.name github-actions
         git config user.email github-actions@github.com
         git remote add -f upstream "https://github.com/18F/isildurs-bane.git"
-        git merge upstream/main
+        git merge --allow-unrelated-histories upstream/main
         git push
       shell: bash


### PR DESCRIPTION
When downstream repository created from GitHub's Use this template feature, the repos won't have a common history like in a fork.