### PR TITLE
Explicitly set ruby version to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM ruby:2.7
+FROM ruby:2.7.1
 
 WORKDIR /usr/src/app
 
 COPY Gemfile Gemfile.lock ./
-RUN gem install bundler && \
-  bundle install
+RUN bundle install
 
 ENV LC_ALL=C.UTF-8
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+ruby '2.7.1'
+
 gem 'jekyll'
 
 # If you put them in a jekyll_plugins group they’ll automatically be required into Jekyll

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -74,7 +74,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.4.0)
-    minitest (5.14.1)
+    minitest (5.14.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
     nokogumbo (2.0.2)
@@ -83,7 +83,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
-    public_suffix (4.0.5)
+    public_suffix (4.0.6)
     rainbow (3.0.0)
     rake (13.0.1)
     rb-fsevent (0.10.4)
@@ -119,6 +119,9 @@ DEPENDENCIES
   jemoji (>= 0.12.0)
   rake
   uswds-jekyll (~> 5.0)
+
+RUBY VERSION
+   ruby 2.7.1p83
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
- Bundler already included with 2.7.1 image
- Lock to specific version of ruby to prevent any unexpected errors from appearing out of blue in downstream guides (bundler versions, etc.)