### PR TITLE
Support _guide/_config.yml, previews, etc. on Federalist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,4 @@ RUN bundle install
 
 ENV LC_ALL=C.UTF-8
 
-CMD bundle exec jekyll serve --config _config.yml,_guide/_config.yml --host 0.0.0.0 --incremental
+CMD bundle exec jekyll serve --host 0.0.0.0 --incremental

--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ To achieve these goals, this repository uses:
   - [`_guide/_data`](./_guide/_data) for only the YAML files and keys that can be altered downstream
   - [`_guide/_pages`](./_guide/_pages) 
 - a separate [`_data/orgs`](./_data/orgs) subdirectory and [site configuration key](https://github.com/18F/isildurs-bane/blob/77b8aece41f4f61988a40cc079a70d07670c11e5/override.yml#L25) to have optional 18F, Solutions, CoE, or PIF branding. TTS-only branding is enabled by default.
-- [a Jekyll generator](./_plugins/override.rb) to override values set from YAML files in `_data`
+- [a Jekyll generator](./_plugins/override.rb) to override values set from YAML files in `_data` and in `_config.yml`
+  - Note: Federalist does not support multiple Jekyll config files (e.g., `--config _config.yml,_guide/_config.yml`), requiring custom code
 - [Git attributes](./.github/actions/merge-template/action.yml#L8) to help ensure this upstream repository does not affect downstream content in `_pages`, etc.
 - `Template repository` setting in GitHub
 
@@ -59,9 +60,3 @@ Once you have instantiated a downstream guide repository and cloned it locally, 
    ```
 
 1. Open http://localhost:4000
-
-If you are not using Docker and choose to run Jekyll directly, be sure to specify `_guide/_config.yml` in the `--config` option:
-
-```sh
-bundle exec jekyll serve --config _config.yml,_guide/_config.yml
-```

--- a/_guide/_data/anchor.yml
+++ b/_guide/_data/anchor.yml
@@ -1,3 +1,2 @@
 edit_page:
   text: "Edit this page"
-last_updated: true

--- a/_plugins/override.rb
+++ b/_plugins/override.rb
@@ -7,30 +7,70 @@ module Jekyll
   # Key precedence is GUIDE_DIR, ORGS_DIR, then _data.
 
   class OverrideGenerator < Generator
-    GUIDE_DIR = File.join("_guide", "_data")
-    ORGS_DIR = File.join("_data", "orgs")
+    GUIDE_CONFIG_PATH = File.join("_guide", "_config.yml")
+    GUIDE_DATA_DIR = File.join("_guide", "_data")
+    ORGS_DATA_DIR = File.join("_data", "orgs")
+
+    TITLE_KEY = "title"
+    DESC_KEY = "description"
+    URL_KEY = "url"
+    GITHUB_KEY = "github_info"
+    SEARCH_HANDLE_KEY = "search_site_handle"
+    ORG_KEY = "org"
 
     safe true
 
     def generate(site)
+      puts site.config[URL_KEY]
+      self.mergeConfig(site, GUIDE_CONFIG_PATH)
+      puts site.config[URL_KEY]
+
+
+      # Supported uswds-jekyll YAMLs (minus file extension)
       yamls = ['header', 'navigation', 'footer', 'theme', 'anchor'] 
 
       # Org-specific key values override those set in _data
       yamls.each do |y|
         if site.config['org']
-          self.merge(site, File.join(ORGS_DIR, site.config['org']), y)
+          self.mergeData(site, File.join(ORGS_DATA_DIR, site.config['org']), y)
         end
       end
 
       # Guide-specific key values override anything preceding it
       yamls.each do |y|
-        self.merge(site, GUIDE_DIR, y)
+        self.mergeData(site, GUIDE_DATA_DIR, y)
       end
 
       # TODO Address favicons.yml special case
+
+      puts site.config
     end
 
-    def merge(site, dir, key)
+    def mergeConfig(site, path)
+      puts "        TODO: Merged " + path
+
+      required = ['title', 'description', 'github_info', 'search_site_handle']
+      optional = [ORG_KEY]
+
+      customizations = YAML.load_file(path)
+      if customizations
+        required.each do |k|
+          site.config[k] = customizations[k]
+        end
+        
+        optional.each do |k|
+          if customizations.key?(k)
+            site.config[k] = customizations[k]
+          end
+        end
+
+        if not site.config.key?(URL_KEY)
+          site.config[URL_KEY] = customizations[URL_KEY]
+        end
+      end
+    end
+
+    def mergeData(site, dir, key)
       begin
         path = File.join(dir, key + '.yml')
         customizations = YAML.load_file(path)

--- a/_plugins/override.rb
+++ b/_plugins/override.rb
@@ -1,86 +1,133 @@
-require 'yaml'
+require "yaml"
 
 module Jekyll
-
   ##
-  # Loads 18F/uswds-jekyll YAML config files in ORGS_DIR and GUIDE_DIR, overriding any keys found in _data.
-  # Key precedence is GUIDE_DIR, ORGS_DIR, then _data.
-
+  # Loads custom, guide-specific config and data under GUIDE_DIR.
+  # Configuration keys are limited to those specified in this class,
+  # orginating from uswds-jekyll, jekyll-sitemap, and isidurs-bane.
+  # Data filenames/keys are limited to those in DATA_FILES.
+  #
   class OverrideGenerator < Generator
-    GUIDE_CONFIG_PATH = File.join("_guide", "_config.yml")
-    GUIDE_DATA_DIR = File.join("_guide", "_data")
+    # Guide-specific directory for configuration, data, and content
+    GUIDE_DIR = "_guide"
+    # Guide-specific configuration file
+    GUIDE_CONFIG = File.join("_guide", "_config.yml")
+
+    # Supported keys in GUIDE_CONFIG:
+
+    # Sets the guide title in the header and anchor, from uswds-jekyll
+    TITLE_KEY = "title"
+    # Sets the guide description in the <meta> element, from uswds-jekyll
+    DESC_KEY = "description"
+    # Sets the URL used in the sitemap.xml, from jekyll-sitemap
+    URL_KEY = "url"
+    # Sets the GitHub repository information for the "Edit this page" link, from uswds-jekyll
+    GITHUB_KEY = "github_info"
+    # Sets the search.gov handle used with the search function in the header, from uswds-jekyll
+    SEARCH_KEY = "search_site_handle"
+    # Sets the organization managing this guide, from isidurs-bane
+    ORG_KEY = "org"
+
+    # Parent directory for org-specific data
     ORGS_DATA_DIR = File.join("_data", "orgs")
 
-    TITLE_KEY = "title"
-    DESC_KEY = "description"
-    URL_KEY = "url"
-    GITHUB_KEY = "github_info"
-    SEARCH_HANDLE_KEY = "search_site_handle"
-    ORG_KEY = "org"
+    # Guide-specific data
+    GUIDE_DATA_DIR = File.join("_guide", "_data")
+
+    # Supported uswds-jekyll and isidurs-bane data files
+    DATA_FILES = ["header.yml", "navigation.yml", "footer.yml", "theme.yml", "anchor.yml"]
 
     safe true
 
+    ##
+    # Merges keys in GUIDE_CONFIG with those set in _config.yml.
+    # Also loads uswds-jekyll and isidurs-bane YAML data files under
+    # ORGS_DATA_DIR and in GUIDE_DATA_DIR, overriding any keys found
+    # in _data. Key precedence is GUIDE_DATA_DIR, then the optional
+    # org-specific sub-directory in ORGS_DATA_DIR, then finally _data.
+    #
+    # This method is run after Jekyll has made an inventory of
+    # the existing content, and before the site is generated, per:
+    # https://jekyllrb.com/docs/plugins/generators/
+    #
     def generate(site)
-      puts site.config[URL_KEY]
-      self.mergeConfig(site, GUIDE_CONFIG_PATH)
-      puts site.config[URL_KEY]
+      merge_config_file(site)
 
+      merge_org_data(site)
 
-      # Supported uswds-jekyll YAMLs (minus file extension)
-      yamls = ['header', 'navigation', 'footer', 'theme', 'anchor'] 
-
-      # Org-specific key values override those set in _data
-      yamls.each do |y|
-        if site.config['org']
-          self.mergeData(site, File.join(ORGS_DATA_DIR, site.config['org']), y)
-        end
-      end
-
-      # Guide-specific key values override anything preceding it
-      yamls.each do |y|
-        self.mergeData(site, GUIDE_DATA_DIR, y)
-      end
-
-      # TODO Address favicons.yml special case
-
-      puts site.config
+      merge_guide_data(site)
     end
 
-    def mergeConfig(site, path)
-      puts "        TODO: Merged " + path
+    private
 
-      required = ['title', 'description', 'github_info', 'search_site_handle']
+    def merge_org_data(site)
+      yamls = DATA_FILES
+      yamls.each do |y|
+        org = site.config[ORG_KEY]
+        if org
+          mergeData(site, File.join(ORGS_DATA_DIR, org), y)
+        end
+      end
+    end
+
+    def merge_guide_data(site)
+      yamls = DATA_FILES
+      yamls.each do |y|
+        mergeData(site, GUIDE_DATA_DIR, y)
+      end
+    end
+
+    ##
+    # Federalist does not allow multiple Jekyll config files to be
+    # specified (i.e., with --config), so this approximates that
+    # Jekyll feature.
+    #
+    def merge_config_file(site)
+      required = [TITLE_KEY, DESC_KEY, GITHUB_KEY, SEARCH_KEY, URL_KEY]
       optional = [ORG_KEY]
 
-      customizations = YAML.load_file(path)
+      original_url = site.config[URL_KEY]
+
+      customizations = YAML.load_file(GUIDE_CONFIG)
       if customizations
         required.each do |k|
           site.config[k] = customizations[k]
         end
-        
+
         optional.each do |k|
           if customizations.key?(k)
             site.config[k] = customizations[k]
           end
         end
 
-        if not site.config.key?(URL_KEY)
-          site.config[URL_KEY] = customizations[URL_KEY]
+        # Per https://jekyllrb.com/docs/variables/, Jekyll will set
+        # the url at runtime in dev environments -- preserve, if set
+        if original_url
+          site.config[URL_KEY] = original_url
         end
       end
+      puts "        Merged " + GUIDE_CONFIG
     end
 
-    def mergeData(site, dir, key)
+    def mergeData(site, dir, file)
+      path = File.join(dir, file)
+      unless File.exist?(path)
+        # Not every org/guide will need to override a given data file
+        return
+      end
+
       begin
-        path = File.join(dir, key + '.yml')
         customizations = YAML.load_file(path)
         if customizations
+          # Per https://jekyllrb.com/docs/datafiles/
+          key = File.basename(path, File.extname(path))
           site.data[key].merge!(customizations)
           puts "        Merged " + path
         end
       rescue
+        puts "         ERROR " + path
+        raise
       end
     end
   end
-
 end

--- a/_plugins/override.rb
+++ b/_plugins/override.rb
@@ -65,7 +65,7 @@ module Jekyll
       yamls.each do |y|
         org = site.config[ORG_KEY]
         if org
-          mergeData(site, File.join(ORGS_DATA_DIR, org), y)
+          merge_data(site, File.join(ORGS_DATA_DIR, org), y)
         end
       end
     end
@@ -73,7 +73,7 @@ module Jekyll
     def merge_guide_data(site)
       yamls = DATA_FILES
       yamls.each do |y|
-        mergeData(site, GUIDE_DATA_DIR, y)
+        merge_data(site, GUIDE_DATA_DIR, y)
       end
     end
 
@@ -109,7 +109,7 @@ module Jekyll
       puts "        Merged " + GUIDE_CONFIG
     end
 
-    def mergeData(site, dir, file)
+    def merge_data(site, dir, file)
       path = File.join(dir, file)
       unless File.exist?(path)
         # Not every org/guide will need to override a given data file

--- a/_sass/_usa_anchor.scss
+++ b/_sass/_usa_anchor.scss
@@ -132,13 +132,13 @@
     }
   }
   .usa-accordion__button[aria-expanded=false]{
-    background-image: url('/assets/images/angle-arrow-down-white.svg'),-webkit-gradient(linear,left top,left bottom,from(transparent),to(transparent));
+    background-image: url('../../assets/images/angle-arrow-down-white.svg'),-webkit-gradient(linear,left top,left bottom,from(transparent),to(transparent));
     background-size: .85rem;
     background-repeat: no-repeat;
     background-position: 6.65em center;
   }
   .usa-accordion__button[aria-expanded=true]{
-    background-image: url('/assets/images/angle-arrow-up-white.svg'),-webkit-gradient(linear,left top,left bottom,from(transparent),to(transparent));
+    background-image: url('../../assets/images/angle-arrow-up-white.svg'),-webkit-gradient(linear,left top,left bottom,from(transparent),to(transparent));
     background-size: .85rem;
     background-repeat: no-repeat;
     background-position: 6.65em center;

--- a/_sass/_uswds-theme-custom-styles.scss
+++ b/_sass/_uswds-theme-custom-styles.scss
@@ -136,7 +136,7 @@ a[href^="https://gsa-tts.slack.com"]::before {
   margin: units(-2px) units(-0.5) 0;
   background-size: 100%;
   background-repeat: no-repeat;
-  background-image: url("/assets/images/Slack_Mark.svg");
+  background-image: url("../../assets/images/Slack_Mark.svg");
 }
 .usa-prose>ul.list-item--margin-bottom-extra>li,
 .usa-prose>ol.list-item--margin-bottom-extra>li {


### PR DESCRIPTION
Federalist doesn't support multiple Jekyll config files, so load `_guide/_config.yml` in the generator.