### PR TITLE
Fix glob used in .gitattributes

### DIFF
--- a/.github/actions/merge-template/action.yml
+++ b/.github/actions/merge-template/action.yml
@@ -6,7 +6,7 @@ runs:
   steps:
     - run: |
         echo 'README.md merge=ours' >> .gitattributes
-        echo '_guide/* merge=ours' >> .gitattributes
+        echo '_guide/** merge=ours' >> .gitattributes
         git config --global merge.ours.driver true
         git config user.name github-actions
         git config user.email github-actions@github.com


### PR DESCRIPTION
.gitattributes patterns use same convention as .gitignore, where trailing `/**` is used to match everything inside a directory.