### PR TITLE
Change default layout to post

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -28,7 +28,7 @@ defaults:
   - scope:
       path: ""
     values:
-      layout: page
+      layout: post
 
 scripts:
   - /assets/uswds/js/uswds.min.js

--- a/_guide/_pages/index.md
+++ b/_guide/_pages/index.md
@@ -1,7 +1,6 @@
 ---
 title: About this guide
 permalink: /
-layout: post
 sidenav: overview
 sticky_sidenav: true
 subnav:

--- a/_guide/_pages/topics/capybaras.md
+++ b/_guide/_pages/topics/capybaras.md
@@ -1,6 +1,5 @@
 ---
 title: Capybaras
-layout: post
 sidenav: topics
 sticky_sidenav: true
 subnav:

--- a/_guide/_pages/topics/dolphins.md
+++ b/_guide/_pages/topics/dolphins.md
@@ -1,6 +1,5 @@
 ---
 title: Dolphins
-layout: post
 sidenav: topics
 sticky_sidenav: true
 subnav:

--- a/_guide/_pages/topics/giraffes.md
+++ b/_guide/_pages/topics/giraffes.md
@@ -1,6 +1,5 @@
 ---
 title: Giraffes
-layout: post
 sidenav: topics
 sticky_sidenav: true
 subnav:


### PR DESCRIPTION
The anchor component we took from ux-guide only works if layout is post, which I belive is related to this uswds-jekyll change: https://github.com/18F/uswds-jekyll/issues/200

Instead of individually setting the layout in each page, set it in the front matter by default:
https://jekyllrb.com/docs/configuration/front-matter-defaults/