### PR TITLE
Dependency updates

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 ruby '2.7.1'
 
 gem 'jekyll'
+gem 'mini_racer'
 
 # If you put them in a jekyll_plugins group they’ll automatically be required into Jekyll
 # One of 3 ways to load plug-ins, don't need to do both

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,14 +9,17 @@ GEM
       zeitwerk (~> 2.2, >= 2.2.2)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    autoprefixer-rails (9.8.6.5)
+      execjs
     colorator (1.1.0)
     concurrent-ruby (1.1.7)
-    em-websocket (0.5.1)
+    em-websocket (0.5.2)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     ethon (0.12.0)
       ffi (>= 1.3.0)
     eventmachine (1.2.7)
+    execjs (2.7.0)
     ffi (1.13.1)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
@@ -49,6 +52,8 @@ GEM
       rouge (~> 3.0)
       safe_yaml (~> 1.0)
       terminal-table (~> 1.8)
+    jekyll-autoprefixer (1.0.2)
+      autoprefixer-rails (~> 9.3)
     jekyll-last-modified-at (1.3.0)
       jekyll (>= 3.7, < 5.0)
       posix-spawn (~> 0.3.9)
@@ -68,12 +73,15 @@ GEM
       rexml
     kramdown-parser-gfm (1.1.0)
       kramdown (~> 2.0)
+    libv8 (8.4.255.0)
     liquid (4.0.3)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     mini_portile2 (2.4.0)
+    mini_racer (0.3.1)
+      libv8 (~> 8.4.255)
     minitest (5.14.2)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
@@ -102,8 +110,9 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    uswds-jekyll (5.0.1)
+    uswds-jekyll (5.2.0)
       jekyll (>= 4.0, < 5)
+      jekyll-autoprefixer
     yell (2.2.2)
     zeitwerk (2.4.0)
 
@@ -117,6 +126,7 @@ DEPENDENCIES
   jekyll-redirect-from
   jekyll-sitemap
   jemoji (>= 0.12.0)
+  mini_racer
   rake
   uswds-jekyll (~> 5.0)
 


### PR DESCRIPTION
Note that autoprefixer-rails, used by uswds-jekyll 5.2.0, requires a JavaScript runtime. I initially tried therubyracer per ExecJS docs, but appears it only? supports mini_racer now.

For now, going with a Ruby-based JavaScript runtime (mini_racer) to avoid pulling in Node.JS (but will probably have to do that sometime soon for additional functionality anyhow).