### PR TITLE
Fix GitHub edit link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -24,7 +24,8 @@
                 {% endif %}
                 {% if anchor.edit_page %}
                 <span>
-                  {% include components/github-edit.html footer=anchor path=page.path %}
+                  {% assign repo_page_path = site.collections_dir | append: "/" | append: page.path %}
+                  {% include components/github-edit.html footer=anchor path=repo_page_path %}
                 </span>
                 {% endif %}
               </p>


### PR DESCRIPTION
Closes #36 

By compartmentalizing all the downstream guide's content under _guide, the path for a page on a web site is different than the path for the corresponding Markdown file in its GitHub repo. This change takes the nesting under `collections_dir` (aka `_guide`) into account (see relevant line in [_config.yml](https://github.com/18F/isildurs-bane/blob/b0b88f85ad0edaa70e3a3bd99fde891d71a56280/_config.yml#L21)).